### PR TITLE
Add Rakefile and log directory to support rake commands

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require File.expand_path('../config/application', __FILE__)
+
+Rails.application.load_tasks


### PR DESCRIPTION
I tried to setup database with the usual way from rake db:setup
and it failed because the project doesn't have a Rakefile,
also when rake is workign it needs logs directory.